### PR TITLE
Query string support for the token

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ All requests to the API need an API token. Generate a token in the [Settings](ht
 Note: Each user may only have one token, so generating a new token will make any previous tokens invalid.
 
 The token is sent in the `X-Authentication-Token` header. For example, using `curl` it'd be `curl -H 'X-Authentication-Token: TOKEN' URL`.
+Alternatively you can send the token in the URL using the `access_token` query string attribute. Using this way, append `?access_token=TOKEN` to any url.
 
 ## Endpoints
 


### PR DESCRIPTION
The api also supports `access_token` query string to set the token instead of the header.
