### PR TITLE
Update API endpoints on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,8 @@ This describes the current version of the public ZenHub API. If you have any que
 
 ## Root Endpoint
 
-The root endpoint for the public API is `https://api.zenhub.io/`. For ZenHub Enterprise, refer to the instructions in `https://<zenhub_enterprise_host>/setup/howto/api`.
+On Cloud, the root endpoint for the public API is `https://api.zenhub.io/`. 
+For ZenHub Enterprise, the root endpoint is `https://<zenhub_enterprise_host>/`.
 
 ## Authentication
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ For ZenHub Enterprise, the root endpoint is `https://<zenhub_enterprise_host>/`.
 
 ## Authentication
 
-All requests to the API need an API token. Generate a token in the **API Tokens** section of your ZenHub [Dashboard](https://app.zenhub.com/dashboard). The token is sent in the `X-Authentication-Token` header. For example, using `curl` it’d be:
+All requests to the API need an API token. Generate a token in the **API Tokens** section of your ZenHub [Dashboard](https://app.zenhub.com/dashboard/tokens) (or `https://<zenhub_enterprise_host>/app/dashboard/tokens` for ZenHub Enterprise). The token is sent in the `X-Authentication-Token` header. For example, using `curl` it’d be:
 
 ```sh
 curl -H 'X-Authentication-Token: TOKEN' URL


### PR DESCRIPTION
Since removing the API page in Enterprise (moved to Dashboard within ZenHub), we can change the wording and endpoint here.