### PR TITLE
Add a link to GH issue status docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ Get the data for a specific issue.
 
 - `plus_ones[].user_id` was removed from the response.
 - `pipeline` object references the oldest Workspace pipeline this issue is in.
-  - **NOTE:** If an issue's status is closed, the `pipeline` value will describe the Pipeline that the issue was in prior to the issue being closed. The ZenHub API does not consider the "Closed" Pipeline to be a distinct Pipeline at this time and you should **not** use the Pipeline value to determine whether or not an issue is closed or open (use `status` instead).
+  - **NOTE:** If an issue's status is closed, the `pipeline` value will describe the Pipeline that the issue was in prior to the issue being closed. The ZenHub API does not consider the "Closed" Pipeline to be a distinct Pipeline at this time and you should **not** use the Pipeline value to determine whether or not an issue is closed or open (use [the GitHub `status`](https://developer.github.com/v3/issues/#parameters) instead).
   - **NOTE:** Reopened issues might take up to one minute to show up in the correct Pipeline.
 - `pipelines` contains all pipelines in all Workspaces this issue is in.
 


### PR DESCRIPTION
Added a link to the GitHub issue status docs when warning users to use that to determine the true status of the issue. 